### PR TITLE
Add locked hbeat on response worker request, using timeout param from request

### DIFF
--- a/src/domogikmq/reqrep/broker.py
+++ b/src/domogikmq/reqrep/broker.py
@@ -414,11 +414,14 @@ class MDPBroker(object):
         """
         service = msg.pop(0)
         try :
-            timeout = float(msg.pop(0))
+            tOut = msg.pop(0)
+            timeout = float(tOut)
         except :
-            self.log.warning("Client REQ received: to='{0}' with bad timeout format : data={1}".format(service, msg))
+            msg.insert(0, tOut)
             timeout = None
-        self.log.debug("Client REQ received: to='{0}' (timeout={1}s) data={2}".format(service, timeout, msg))
+            self.log.debug("Client REQ received: to='{0}' without timeout : data={1}".format(service, msg))
+        else :
+            self.log.debug("Client REQ received: to='{0}' (timeout={1}s) data={2}".format(service, timeout, msg))
         if service.startswith(b'mmi.'):
             self.on_mmi(rp, service, msg)
             return

--- a/src/domogikmq/reqrep/broker.py
+++ b/src/domogikmq/reqrep/broker.py
@@ -21,7 +21,7 @@ __license__ = """
 __author__ = 'Guido Goldstein'
 __email__ = 'gst-py@a-nugget.de'
 
-
+import time
 import zmq
 #import daemon
 from domogikmq.common.daemon import daemon
@@ -300,6 +300,7 @@ class MDPBroker(object):
             wq, wr = self._services[service]
             cp, msg = split_address(msg)
             self.client_response(cp, service, msg)
+            wrep.unlockhbeat()
             wq.put(wrep.id)
             if wr:
                 proto, rp, msg = wr.pop(0)
@@ -412,7 +413,12 @@ class MDPBroker(object):
         :rtype: None
         """
         service = msg.pop(0)
-        self.log.debug("Client REQ received: to='{0}' data={1}".format(service, msg))
+        try :
+            timeout = float(msg.pop(0))
+        except :
+            self.log.warning("Client REQ received: to='{0}' with bad timeout format : data={1}".format(service, msg))
+            timeout = None
+        self.log.debug("Client REQ received: to='{0}' (timeout={1}s) data={2}".format(service, timeout, msg))
         if service.startswith(b'mmi.'):
             self.on_mmi(rp, service, msg)
             return
@@ -426,6 +432,8 @@ class MDPBroker(object):
                 wr.append((proto, rp, msg))
                 return
             wrep = self._workers[wid]
+            if timeout is not None :
+                wrep.lockhbeat(timeout)
             to_send = [ wrep.id, b'', self.WORKER_PROTO, b'\x02']
             to_send.extend(rp)
             to_send.append(b'')
@@ -511,15 +519,39 @@ class WorkerRep(object):
     """
 
     def __init__(self, proto, wid, service, stream):
+        l = logger.Logger('mq_broker')
+        self.log = l.get_logger()
+
         self.proto = proto
         self.id = wid
         self.service = service
         self.curr_liveness = HB_LIVENESS
         self.stream = stream
         self.last_hb = 0
+        self._startLockHB = 0
+        self._timeOut = 0
         self.hb_out_timer = PeriodicCallback(self.send_hb, HB_INTERVAL)
         self.hb_out_timer.start()
         return
+
+    def lockhbeat(self, timeOut):
+        """Lock heartbeat process during timeout to preserve rep from client req
+        """
+        self.log.debug("WorkerRep {0} HBeat Locked for {1} s...".format(self.service, timeOut))
+        self._startLockHB = time.time()
+        self._timeOut = timeOut
+
+    def unlockhbeat(self):
+        """Unlock heartbeat process
+        """
+        self.log.debug("WorkerRep {0} HBeat Unlocked".format(self.service))
+        self._startLockHB = 0
+        self._timeOut = 0
+
+    def get_lockhbeat(self):
+        """Get ock heartbeat status
+        """
+        return self._startLockHB != 0
 
     def send_hb(self):
         """Called on every HB_INTERVAL.
@@ -528,9 +560,15 @@ class WorkerRep(object):
 
         Sends heartbeat to worker.
         """
-        self.curr_liveness -= 1
-        msg = [ self.id, b'', self.proto, b'\x04' ]
-        self.stream.send_multipart(msg)
+        if self.get_lockhbeat() :
+            if time.time() >= self._startLockHB + self._timeOut :
+                self.log.warning("WorkerRep {0} HBeat lock timeout {1} s".format(self.service, self._timeOut))
+                self.log.debug(u"{0}, {1}".format(self._startLockHB + self._timeOut,  time.time()))
+                self.unlockhbeat()
+        if not self.get_lockhbeat() :
+            self.curr_liveness -= 1
+            msg = [ self.id, b'', self.proto, b'\x04' ]
+            self.stream.send_multipart(msg)
         return
 
     def on_heartbeat(self):

--- a/src/domogikmq/reqrep/client.py
+++ b/src/domogikmq/reqrep/client.py
@@ -27,6 +27,7 @@ __email__ = 'gst-py@a-nugget.de'
 
 import zmq
 import sys
+
 from zmq.eventloop.zmqstream import ZMQStream
 from zmq.eventloop.ioloop import IOLoop, DelayedCallback
 from zmq import select
@@ -64,7 +65,7 @@ class MQSyncReq(object):
             config['ip'] = get_ip()
         endpoint = "tcp://{0}:{1}".format(config['ip'], config['req_rep_port'])
         self.socket = ZmqSocket(context, zmq.REQ)
-        self.socket.connect(endpoint)         
+        self.socket.connect(endpoint)
         return
 
     def shutdown(self):
@@ -95,7 +96,7 @@ class MQSyncReq(object):
             msg = [msg]
         elif type(msg) is str:
             msg = [str.encode(msg)]
-        to_send = [self._proto_version, str.encode(service)]
+        to_send = [self._proto_version, str.encode(service), str(timeout)]
         to_send.extend(msg)
         self.socket.send_multipart(to_send)
         ret = None
@@ -113,7 +114,7 @@ class MQSyncReq(object):
         :type msg:      list of str
         :param timeout: time to wait in milliseconds.
         :type timeout:  int
-        
+
         :rtype : message parts
         """
         ret = self.rawrequest( service, msg, timeout)
@@ -202,7 +203,7 @@ class MqAsyncReq(object):
         :type msg:      list of str
         :param timeout: time to wait in milliseconds.
         :type timeout:  int
-        
+
         :rtype None:
         """
         if not self.can_send:


### PR DESCRIPTION
Proposal to fix [domogik issue #328](https://github.com/domogik/domogik/issues/328)

This patch add a locking hbeat WorkerRep class on worker request to avoid hbeat request when worker is busy and can't response to hbeat.
Timeout param is transmit on client MQ message and using to unclock hbeat if it's outdated.

This lock system work to fix issue on my install.
See code diff:

```
diff --git a/src/domogikmq/reqrep/broker.py b/src/domogikmq/reqrep/broker.py
index 78cae13..7eddcef 100644
--- a/src/domogikmq/reqrep/broker.py
+++ b/src/domogikmq/reqrep/broker.py
@@ -21,7 +21,7 @@ __license__ = """
 __author__ = 'Guido Goldstein'
 __email__ = 'gst-py@a-nugget.de'

-
+import time
 import zmq
 #import daemon
 from domogikmq.common.daemon import daemon
@@ -300,6 +300,7 @@ class MDPBroker(object):
             wq, wr = self._services[service]
             cp, msg = split_address(msg)
             self.client_response(cp, service, msg)
+            wrep.unlockhbeat()
             wq.put(wrep.id)
             if wr:
                 proto, rp, msg = wr.pop(0)
@@ -412,7 +413,12 @@ class MDPBroker(object):
         :rtype: None
         """
         service = msg.pop(0)
-        self.log.debug("Client REQ received: to='{0}' data={1}".format(service, msg))
+        try :
+            timeout = float(msg.pop(0))
+        except :
+            self.log.warning("Client REQ received: to='{0}' with bad timeout format : data={1}".format(service, msg))
+            timeout = None
+        self.log.debug("Client REQ received: to='{0}' (timeout={1}s) data={2}".format(service, timeout, msg))
         if service.startswith(b'mmi.'):
             self.on_mmi(rp, service, msg)
             return
         try:
             wq, wr = self._services[service]
             wid = wq.get()
             if not wid:
                 # no worker ready
                 # queue message
                 msg.insert(0, service)                 wr.append((proto, rp, msg))
                 return
             wrep = self._workers[wid]
+            if timeout is not None :
+                wrep.lockhbeat(timeout)
             to_send = [ wrep.id, b'', self.WORKER_PROTO, b'\x02']
             to_send.extend(rp)
             to_send.append(b'')
@@ -511,16 +519,40 @@ class WorkerRep(object):
     """

     def __init__(self, proto, wid, service, stream):
+        l = logger.Logger('mq_broker')
+        self.log = l.get_logger()
+
         self.proto = proto
         self.id = wid
         self.service = service
         self.curr_liveness = HB_LIVENESS
         self.stream = stream
         self.last_hb = 0
+        self._startLockHB = 0
+        self._timeOut = 0
         self.hb_out_timer = PeriodicCallback(self.send_hb, HB_INTERVAL)
         self.hb_out_timer.start()
         return

+    def lockhbeat(self, timeOut):
+        """Lock heartbeat process during timeout to preserve rep from client req
+        """
+        self.log.debug("WorkerRep {0} HBeat Locked for {1} s...".format(self.service, timeOut))
+        self._startLockHB = time.time()
+        self._timeOut = timeOut
+
+    def unlockhbeat(self):
+        """Unlock heartbeat process
+        """
+        self.log.debug("WorkerRep {0} HBeat Unlocked".format(self.service))
+        self._startLockHB = 0
+        self._timeOut = 0
+
+    def get_lockhbeat(self):
+        """Get ock heartbeat status
+        """
+        return self._startLockHB != 0
+
     def send_hb(self):
         """Called on every HB_INTERVAL.

@@ -528,9 +560,15 @@ class WorkerRep(object):

         Sends heartbeat to worker.
         """
-        self.curr_liveness -= 1
-        msg = [ self.id, b'', self.proto, b'\x04' ]
-        self.stream.send_multipart(msg)
+        if self.get_lockhbeat() :
+            if time.time() >= self._startLockHB + self._timeOut :
+                self.log.warning("WorkerRep {0} HBeat lock timeout {1} s".format(self.service, self._timeOut))
+                self.log.debug(u"{0}, {1}".format(self._startLockHB + self._timeOut,  time.time()))
+                self.unlockhbeat()
+        if not self.get_lockhbeat() :
+            self.curr_liveness -= 1
+            msg = [ self.id, b'', self.proto, b'\x04' ]
+            self.stream.send_multipart(msg)
         return

     def on_heartbeat(self):
```

```
diff --git a/src/domogikmq/reqrep/client.py b/src/domogikmq/reqrep/client.py
index de56635..207e497 100644
--- a/src/domogikmq/reqrep/client.py
+++ b/src/domogikmq/reqrep/client.py
@@ -95,7 +96,7 @@ class MQSyncReq(object):
             msg = [msg]
         elif type(msg) is str:
             msg = [str.encode(msg)]
-        to_send = [self._proto_version, str.encode(service)]
+        to_send = [self._proto_version, str.encode(service), str(timeout)]
         to_send.extend(msg)
         self.socket.send_multipart(to_send)
```
